### PR TITLE
Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Esse repo contém o material de apoio para o curso Masterclass GoLang (Impacta)
 Para instalar o compilador e ferramentas do GoLang, basta fazer o download da versão apropriada ao
 seu sistema operacional no seguinte caminho: [Download GoLang](https://go.dev/dl/)
 
-Caso utilize o VSC, é recomendável instalar a seguinte extenção: __Go for Visual Studio Code__
+Caso utilize o VSC, é recomendável instalar a seguinte extensão: __Go for Visual Studio Code__
 Essa extensão recursos de ênfase para a sintaxe, auto-complete para o código, preenchimento
 automático dos pacotes de dependências, navegação fácil por todo o código, diagnóstico, sugestões,
 debug e testes.


### PR DESCRIPTION
## Summary
- fix typo 'extenção' -> 'extensão'

## Testing
- `grep -n "exten" README.md`

------
https://chatgpt.com/codex/tasks/task_e_684452bd7fd0832bb50a72e08597f72f