### PR TITLE
Fix zero timeout in RestAPI

### DIFF
--- a/RestAPI/servidorAPI.go
+++ b/RestAPI/servidorAPI.go
@@ -26,6 +26,10 @@ func (a *ServidorAPI) lerConfig() error {
 	a.databaseURL = os.Getenv("DATABASEURL")
 	a.porta = os.Getenv("SERVICEPORT")
 
+	// define um timeout padrao para a conexao com o banco de dados
+	// evitando que um valor zero cancele o contexto imediatamente
+	a.timeout = 10 * time.Second
+
 	if len(a.porta) == 0 {
 		a.porta = ":8080"
 	} else if a.porta[0] != ':' {


### PR DESCRIPTION
## Summary
- set default MongoDB connection timeout in the REST API server

## Testing
- `go test ./...` *(fails: cannot fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_684451db5c40832ba9c3a94b78c4be31